### PR TITLE
Implement the data access layer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 		android:supportsRtl="true"
 		android:theme="@style/AppTheme"
 		tools:ignore="AllowBackup,GoogleAppIndexingWarning">
-		<activity android:name=".MainActivity">
+		<activity android:name=".activities.MainActivity">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
 				<category android:name="android.intent.category.LAUNCHER"/>

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/MainActivity.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/MainActivity.java
@@ -6,15 +6,19 @@ import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.widget.TextView;
 
+import java.util.List;
+
 import dagger.android.DaggerActivity;
+import ua.edu.lnu.ami.flagsquiz.models.Region;
+import ua.edu.lnu.ami.flagsquiz.services.RegionService;
 
 public class MainActivity extends DaggerActivity {
 	
-	private String injectedString;
+	private RegionService regionService;
 	
 	@Inject
-	void setInjectedString(String injectedString) {
-		this.injectedString = injectedString;
+	void setRegionService(RegionService regionService) {
+		this.regionService = regionService;
 	}
 	
 	@Override
@@ -23,7 +27,9 @@ public class MainActivity extends DaggerActivity {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_main);
 		
+		List<Region> regions = regionService.getAll();
+		
 		TextView target = findViewById(R.id.target);
-		target.setText("The injected string is: " + injectedString);
+		target.setText("The amount of regions is: " + regions.size());
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/activities/MainActivity.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/activities/MainActivity.java
@@ -1,4 +1,6 @@
-package ua.edu.lnu.ami.flagsquiz;
+package ua.edu.lnu.ami.flagsquiz.activities;
+
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -6,15 +8,23 @@ import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.widget.TextView;
 
-import java.util.List;
-
 import dagger.android.DaggerActivity;
+
+import ua.edu.lnu.ami.flagsquiz.R;
+import ua.edu.lnu.ami.flagsquiz.models.Country;
 import ua.edu.lnu.ami.flagsquiz.models.Region;
+import ua.edu.lnu.ami.flagsquiz.services.CountryService;
 import ua.edu.lnu.ami.flagsquiz.services.RegionService;
 
 public class MainActivity extends DaggerActivity {
 	
+	private CountryService countryService;
 	private RegionService regionService;
+	
+	@Inject
+	void setCountryService(CountryService countryService) {
+		this.countryService = countryService;
+	}
 	
 	@Inject
 	void setRegionService(RegionService regionService) {
@@ -28,8 +38,10 @@ public class MainActivity extends DaggerActivity {
 		setContentView(R.layout.activity_main);
 		
 		List<Region> regions = regionService.getAll();
+		List<Country> countries = countryService.getAll();
 		
 		TextView target = findViewById(R.id.target);
-		target.setText("The amount of regions is: " + regions.size());
+		target.setText("# of regions: " + regions.size() + "; " +
+			"# of countries: " + countries.size());
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/activities/MainActivity.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/activities/MainActivity.java
@@ -13,13 +13,16 @@ import dagger.android.DaggerActivity;
 import ua.edu.lnu.ami.flagsquiz.R;
 import ua.edu.lnu.ami.flagsquiz.models.Country;
 import ua.edu.lnu.ami.flagsquiz.models.Region;
+import ua.edu.lnu.ami.flagsquiz.models.Statistics;
 import ua.edu.lnu.ami.flagsquiz.services.CountryService;
 import ua.edu.lnu.ami.flagsquiz.services.RegionService;
+import ua.edu.lnu.ami.flagsquiz.services.StatisticsService;
 
 public class MainActivity extends DaggerActivity {
 	
 	private CountryService countryService;
 	private RegionService regionService;
+	private StatisticsService statisticsService;
 	
 	@Inject
 	void setCountryService(CountryService countryService) {
@@ -31,6 +34,11 @@ public class MainActivity extends DaggerActivity {
 		this.regionService = regionService;
 	}
 	
+	@Inject
+	void setStatisticsService(StatisticsService statisticsService) {
+		this.statisticsService = statisticsService;
+	}
+	
 	@Override
 	@SuppressLint("SetTextI18n")
 	protected void onCreate(Bundle savedInstanceState) {
@@ -39,9 +47,11 @@ public class MainActivity extends DaggerActivity {
 		
 		List<Region> regions = regionService.getAll();
 		List<Country> countries = countryService.getAll();
+		List<Statistics> statistics = statisticsService.getAll();
 		
 		TextView target = findViewById(R.id.target);
 		target.setText("# of regions: " + regions.size() + "; " +
-			"# of countries: " + countries.size());
+			"# of countries: " + countries.size() + "; " +
+			"# of stats entries: " + statistics.size());
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
@@ -6,6 +6,7 @@ import dagger.Component;
 import dagger.android.AndroidInjectionModule;
 import dagger.android.AndroidInjector;
 import ua.edu.lnu.ami.flagsquiz.FlagsQuizApp;
+import ua.edu.lnu.ami.flagsquiz.services.RegionService;
 
 /**
  * <p>
@@ -18,4 +19,5 @@ import ua.edu.lnu.ami.flagsquiz.FlagsQuizApp;
 @Singleton
 public interface FlagsQuizAppComponent extends AndroidInjector<FlagsQuizApp> {
 	String provideString();
+	RegionService provideRegionService();
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
@@ -5,7 +5,9 @@ import javax.inject.Singleton;
 import dagger.Component;
 import dagger.android.AndroidInjectionModule;
 import dagger.android.AndroidInjector;
+
 import ua.edu.lnu.ami.flagsquiz.FlagsQuizApp;
+import ua.edu.lnu.ami.flagsquiz.services.CountryService;
 import ua.edu.lnu.ami.flagsquiz.services.RegionService;
 
 /**
@@ -18,5 +20,6 @@ import ua.edu.lnu.ami.flagsquiz.services.RegionService;
 @Component(modules = { AndroidInjectionModule.class, FlagsQuizAppModule.class })
 @Singleton
 public interface FlagsQuizAppComponent extends AndroidInjector<FlagsQuizApp> {
+	CountryService provideCountryService();
 	RegionService provideRegionService();
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
@@ -18,6 +18,5 @@ import ua.edu.lnu.ami.flagsquiz.services.RegionService;
 @Component(modules = { AndroidInjectionModule.class, FlagsQuizAppModule.class })
 @Singleton
 public interface FlagsQuizAppComponent extends AndroidInjector<FlagsQuizApp> {
-	String provideString();
 	RegionService provideRegionService();
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppComponent.java
@@ -7,8 +7,7 @@ import dagger.android.AndroidInjectionModule;
 import dagger.android.AndroidInjector;
 
 import ua.edu.lnu.ami.flagsquiz.FlagsQuizApp;
-import ua.edu.lnu.ami.flagsquiz.services.CountryService;
-import ua.edu.lnu.ami.flagsquiz.services.RegionService;
+import ua.edu.lnu.ami.flagsquiz.services.*;
 
 /**
  * <p>
@@ -22,4 +21,5 @@ import ua.edu.lnu.ami.flagsquiz.services.RegionService;
 public interface FlagsQuizAppComponent extends AndroidInjector<FlagsQuizApp> {
 	CountryService provideCountryService();
 	RegionService provideRegionService();
+	StatisticsService provideStatisticsService();
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
@@ -22,12 +22,6 @@ public abstract class FlagsQuizAppModule {
 	
 	@Provides
 	@Singleton
-	public static String provideString() {
-		return "Hello world!";
-	}
-	
-	@Provides
-	@Singleton
 	public static RegionService provideRegionService() {
 		return new RegionServiceImpl();
 	}

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
@@ -6,9 +6,9 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.android.ContributesAndroidInjector;
 
-import ua.edu.lnu.ami.flagsquiz.MainActivity;
-import ua.edu.lnu.ami.flagsquiz.services.RegionService;
-import ua.edu.lnu.ami.flagsquiz.services.impl.RegionServiceImpl;
+import ua.edu.lnu.ami.flagsquiz.activities.MainActivity;
+import ua.edu.lnu.ami.flagsquiz.services.*;
+import ua.edu.lnu.ami.flagsquiz.services.impl.*;
 
 /**
  * <p>Represents a module which provides Dagger with necessary instances.</p>
@@ -19,6 +19,12 @@ public abstract class FlagsQuizAppModule {
 	
 	@ContributesAndroidInjector
 	public abstract MainActivity contributeActivityInjector();
+	
+	@Provides
+	@Singleton
+	public static CountryService provideCountryService() {
+		return new CountryServiceImpl();
+	}
 	
 	@Provides
 	@Singleton

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
@@ -18,7 +18,7 @@ import ua.edu.lnu.ami.flagsquiz.services.impl.*;
 public abstract class FlagsQuizAppModule {
 	
 	@ContributesAndroidInjector
-	public abstract MainActivity contributeActivityInjector();
+	public abstract MainActivity contributeMainActivityInjector();
 	
 	@Provides
 	@Singleton
@@ -30,5 +30,11 @@ public abstract class FlagsQuizAppModule {
 	@Singleton
 	public static RegionService provideRegionService() {
 		return new RegionServiceImpl();
+	}
+	
+	@Provides
+	@Singleton
+	public static StatisticsService provideStatisticsService() {
+		return new StatisticsServiceImpl();
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/di/FlagsQuizAppModule.java
@@ -7,6 +7,8 @@ import dagger.Provides;
 import dagger.android.ContributesAndroidInjector;
 
 import ua.edu.lnu.ami.flagsquiz.MainActivity;
+import ua.edu.lnu.ami.flagsquiz.services.RegionService;
+import ua.edu.lnu.ami.flagsquiz.services.impl.RegionServiceImpl;
 
 /**
  * <p>Represents a module which provides Dagger with necessary instances.</p>
@@ -22,5 +24,11 @@ public abstract class FlagsQuizAppModule {
 	@Singleton
 	public static String provideString() {
 		return "Hello world!";
+	}
+	
+	@Provides
+	@Singleton
+	public static RegionService provideRegionService() {
+		return new RegionServiceImpl();
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Country.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Country.java
@@ -52,6 +52,6 @@ public class Country extends SugarRecord {
 	
 	@Override
 	public String toString() {
-		return "Country: " + name;
+		return "Country #" + getId() + ": " + name;
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Country.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Country.java
@@ -17,6 +17,15 @@ public class Country extends SugarRecord {
 	
 	private Region region;
 	
+	public Country() {
+	}
+	
+	public Country(String name, String imagePath, Region region) {
+		this.name = name;
+		this.imagePath = imagePath;
+		this.region = region;
+	}
+	
 	public String getName() {
 		return name;
 	}
@@ -39,5 +48,10 @@ public class Country extends SugarRecord {
 	
 	public void setRegion(Region region) {
 		this.region = region;
+	}
+	
+	@Override
+	public String toString() {
+		return "Country: " + name;
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Region.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Region.java
@@ -29,6 +29,6 @@ public class Region extends SugarRecord {
 	
 	@Override
 	public String toString() {
-		return "Region: " + name;
+		return "Region #" + getId() + ": " + name;
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Region.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Region.java
@@ -12,11 +12,23 @@ public class Region extends SugarRecord {
 	@Unique
 	private String name;
 	
+	public Region() {
+	}
+	
+	public Region(String name) {
+		this.name = name;
+	}
+	
 	public String getName() {
 		return name;
 	}
 	
 	public void setName(String name) {
 		this.name = name;
+	}
+	
+	@Override
+	public String toString() {
+		return "Region: " + name;
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Statistics.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Statistics.java
@@ -49,7 +49,7 @@ public class Statistics extends SugarRecord {
 	
 	@Override
 	public String toString() {
-		return "Statistics: " + dateTime + "; # of questions: " +
+		return "Statistics #" + getId() + ": " + dateTime + "; # of questions: " +
 			numQuestions + "; # of attempts: " + numAttempts;
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Statistics.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/models/Statistics.java
@@ -14,6 +14,15 @@ public class Statistics extends SugarRecord {
 	private int numQuestions;
 	private int numAttempts;
 	
+	public Statistics() {
+	}
+	
+	public Statistics(Date dateTime, int numQuestions, int numAttempts) {
+		this.dateTime = dateTime;
+		this.numQuestions = numQuestions;
+		this.numAttempts = numAttempts;
+	}
+	
 	public Date getDateTime() {
 		return dateTime;
 	}
@@ -36,5 +45,11 @@ public class Statistics extends SugarRecord {
 	
 	public void setNumAttempts(int numAttempts) {
 		this.numAttempts = numAttempts;
+	}
+	
+	@Override
+	public String toString() {
+		return "Statistics: " + dateTime + "; # of questions: " +
+			numQuestions + "; # of attempts: " + numAttempts;
 	}
 }

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/CountryService.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/CountryService.java
@@ -1,0 +1,15 @@
+package ua.edu.lnu.ami.flagsquiz.services;
+
+import java.util.List;
+
+import ua.edu.lnu.ami.flagsquiz.models.Country;
+
+/**
+ * <p>Represents a service for getting countries from the database.</p>
+ * @author Tolik Pylypchuk
+ */
+public interface CountryService {
+	
+	Country getById(Long id);
+	List<Country> getAll();
+}

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/RegionService.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/RegionService.java
@@ -1,0 +1,15 @@
+package ua.edu.lnu.ami.flagsquiz.services;
+
+import java.util.List;
+
+import ua.edu.lnu.ami.flagsquiz.models.Region;
+
+/**
+ * <p>Represents a service for getting regions from the database.</p>
+ * @author Tolik Pylypchuk
+ */
+public interface RegionService {
+	
+	Region getById(Long id);
+	List<Region> getAll();
+}

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/StatisticsService.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/StatisticsService.java
@@ -1,0 +1,19 @@
+package ua.edu.lnu.ami.flagsquiz.services;
+
+import java.util.List;
+
+import ua.edu.lnu.ami.flagsquiz.models.Statistics;
+
+/**
+ * <p>Represents a service for CRUD operations on statistics.</p>
+ * @author Tolik Pylypchuk
+ */
+public interface StatisticsService {
+	
+	Statistics getById(Long id);
+	List<Statistics> getAll();
+	
+	long save(Statistics statistics);
+	void delete(Long id);
+	void deleteAll();
+}

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/CountryServiceImpl.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/CountryServiceImpl.java
@@ -1,0 +1,29 @@
+package ua.edu.lnu.ami.flagsquiz.services.impl;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.orm.SugarRecord;
+import com.orm.query.Select;
+
+import ua.edu.lnu.ami.flagsquiz.models.Country;
+import ua.edu.lnu.ami.flagsquiz.services.CountryService;
+
+/**
+ * <p>Represents an implementation of a service for getting countries from the database.</p>
+ * @author Tolik Pylypchuk
+ */
+public class CountryServiceImpl implements CountryService {
+	
+	
+	@Override
+	public Country getById(Long id) {
+		id = Objects.requireNonNull(id, "Id must not be null.");
+		return SugarRecord.findById(Country.class, id);
+	}
+	
+	@Override
+	public List<Country> getAll() {
+		return Select.from(Country.class).list();
+	}
+}

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/CountryServiceImpl.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/CountryServiceImpl.java
@@ -18,7 +18,7 @@ public class CountryServiceImpl implements CountryService {
 	
 	@Override
 	public Country getById(Long id) {
-		id = Objects.requireNonNull(id, "Id must not be null.");
+		Objects.requireNonNull(id, "Id must not be null.");
 		return SugarRecord.findById(Country.class, id);
 	}
 	

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/RegionServiceImpl.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/RegionServiceImpl.java
@@ -17,7 +17,7 @@ public class RegionServiceImpl implements RegionService {
 	
 	@Override
 	public Region getById(Long id) {
-		id = Objects.requireNonNull(id, "Id must not be null.");
+		Objects.requireNonNull(id, "Id must not be null.");
 		return SugarRecord.findById(Region.class, id);
 	}
 	

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/RegionServiceImpl.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/RegionServiceImpl.java
@@ -1,0 +1,28 @@
+package ua.edu.lnu.ami.flagsquiz.services.impl;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.orm.SugarRecord;
+import com.orm.query.Select;
+
+import ua.edu.lnu.ami.flagsquiz.models.Region;
+import ua.edu.lnu.ami.flagsquiz.services.RegionService;
+
+/**
+ * <p>Represents an implementation of a service for getting regions from the database.</p>
+ * @author Tolik Pylypchuk
+ */
+public class RegionServiceImpl implements RegionService {
+	
+	@Override
+	public Region getById(Long id) {
+		id = Objects.requireNonNull(id, "Id must not be null.");
+		return SugarRecord.findById(Region.class, id);
+	}
+	
+	@Override
+	public List<Region> getAll() {
+		return Select.from(Region.class).list();
+	}
+}

--- a/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/StatisticsServiceImpl.java
+++ b/app/src/main/java/ua/edu/lnu/ami/flagsquiz/services/impl/StatisticsServiceImpl.java
@@ -1,0 +1,48 @@
+package ua.edu.lnu.ami.flagsquiz.services.impl;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.orm.SugarRecord;
+import com.orm.query.Select;
+
+import ua.edu.lnu.ami.flagsquiz.models.Statistics;
+import ua.edu.lnu.ami.flagsquiz.services.StatisticsService;
+
+/**
+ * <p>Represents an implementation of a service for CRUD operations on statistics.</p>
+ * @author Tolik Pylypchuk
+ */
+public class StatisticsServiceImpl implements StatisticsService {
+	
+	@Override
+	public Statistics getById(Long id) {
+		Objects.requireNonNull(id, "Id must not be null.");
+		return SugarRecord.findById(Statistics.class, id);
+	}
+	
+	@Override
+	public List<Statistics> getAll() {
+		return Select.from(Statistics.class).list();
+	}
+	
+	@Override
+	public long save(Statistics statistics) {
+		Objects.requireNonNull(statistics, "The statistics must not be null");
+		Objects.requireNonNull(
+			statistics.getDateTime(), "The statistics' date and time must not be null");
+		
+		return SugarRecord.save(statistics);
+	}
+	
+	@Override
+	public void delete(Long id) {
+		id = Objects.requireNonNull(id, "Id must not be null.");
+		SugarRecord.deleteAll(Statistics.class, "id = ?", id.toString());
+	}
+	
+	@Override
+	public void deleteAll() {
+		SugarRecord.deleteAll(Statistics.class);
+	}
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,7 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	tools:context="ua.edu.lnu.ami.flagsquiz.MainActivity">
+	tools:context="ua.edu.lnu.ami.flagsquiz.activities.MainActivity">
 	
 	<TextView
 		android:id="@+id/target"


### PR DESCRIPTION
In this pull request I'll create the data access layer - a set of services for accessing and manipulating entities from the database.

Services for regions and countries will only include reading capabilities, because modifying them is not needed in the app. The statistics service will include all CRUD operations.

As all entities extend the SugarRecord class, they can be manipulated directly. Please don't do that. Use the services instead, because they include the necessary validation logic.